### PR TITLE
[COMMON] API Payload 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 **/application.yml
+**/application-test.yml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/weve/common/api/exception/ExceptionAdvice.java
+++ b/src/main/java/com/weve/common/api/exception/ExceptionAdvice.java
@@ -1,0 +1,121 @@
+package com.weve.common.api.exception;
+
+import com.weve.common.api.payload.BasicResponse;
+import com.weve.common.api.payload.code.ErrorReasonDTO;
+import com.weve.common.api.payload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"),request, errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity<?> onThrowException(GeneralException generalException, HttpServletRequest request) {
+        log.info(generalException.getMessage());
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        BasicResponse<Object> body = BasicResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        BasicResponse<Object> body = BasicResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        BasicResponse<Object> body = BasicResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        BasicResponse<Object> body = BasicResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/com/weve/common/api/exception/GeneralException.java
+++ b/src/main/java/com/weve/common/api/exception/GeneralException.java
@@ -1,0 +1,26 @@
+package com.weve.common.api.exception;
+
+import com.weve.common.api.payload.code.BaseErrorCode;
+import com.weve.common.api.payload.code.ErrorReasonDTO;
+import lombok.Getter;
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public GeneralException(BaseErrorCode code){
+        super(code.getReason().getCode() + ": " + code.getReason().getMessage());
+        this.code = code;
+    }
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+
+
+}

--- a/src/main/java/com/weve/common/api/payload/BasicResponse.java
+++ b/src/main/java/com/weve/common/api/payload/BasicResponse.java
@@ -1,0 +1,36 @@
+package com.weve.common.api.payload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.weve.common.api.payload.code.BaseCode;
+import com.weve.common.api.payload.code.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class BasicResponse<T> {
+
+	@JsonProperty
+	private final Boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private T result;
+
+	// 성공한 경우 응답 생성
+	public static <T> BasicResponse<T> onSuccess(T result){
+		return new BasicResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+	}
+
+	public static <T> BasicResponse<T> of(BaseCode code, T result){
+		return new BasicResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+	}
+
+	// 실패한 경우
+	public static <T> BasicResponse<T> onFailure(String code, String message, T data) {
+		return new BasicResponse<>(false, code, message, data);
+	}
+}

--- a/src/main/java/com/weve/common/api/payload/code/BaseCode.java
+++ b/src/main/java/com/weve/common/api/payload/code/BaseCode.java
@@ -1,0 +1,6 @@
+package com.weve.common.api.payload.code;
+
+public interface BaseCode {
+    public ReasonDTO getReason();
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/weve/common/api/payload/code/BaseErrorCode.java
+++ b/src/main/java/com/weve/common/api/payload/code/BaseErrorCode.java
@@ -1,0 +1,6 @@
+package com.weve.common.api.payload.code;
+
+public interface BaseErrorCode {
+    public ErrorReasonDTO getReason();
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/weve/common/api/payload/code/ErrorReasonDTO.java
+++ b/src/main/java/com/weve/common/api/payload/code/ErrorReasonDTO.java
@@ -1,0 +1,20 @@
+package com.weve.common.api.payload.code;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "httpStatus", "code", "message"})
+public class ErrorReasonDTO {
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/weve/common/api/payload/code/ReasonDTO.java
+++ b/src/main/java/com/weve/common/api/payload/code/ReasonDTO.java
@@ -1,0 +1,20 @@
+package com.weve.common.api.payload.code;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "httpStatus", "code", "message"})
+public class ReasonDTO {
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
@@ -1,0 +1,45 @@
+package com.weve.common.api.payload.code.status;
+
+import com.weve.common.api.payload.code.BaseErrorCode;
+import com.weve.common.api.payload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 일반적인 에러
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    _ENUM_TYPE_NOT_MATCH(HttpStatus.BAD_REQUEST, "COMMON404", "일치하는 타입이 없습니다"),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER400", "존재하지 않는 유저 정보입니다."),
+    INVALID_USER_TYPE(HttpStatus.CONFLICT, "USER401", "적절하지 않은 유저 타입입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/weve/common/api/payload/code/status/SuccessStatus.java
+++ b/src/main/java/com/weve/common/api/payload/code/status/SuccessStatus.java
@@ -1,0 +1,37 @@
+package com.weve.common.api.payload.code.status;
+
+import com.weve.common.api.payload.code.BaseCode;
+import com.weve.common.api.payload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/weve/controller/WorryController.java
+++ b/src/main/java/com/weve/controller/WorryController.java
@@ -1,0 +1,32 @@
+package com.weve.controller;
+
+import com.weve.common.api.payload.BasicResponse;
+import com.weve.dto.request.CreateWorryRequest;
+import com.weve.dto.response.CreateWorryResponse;
+import com.weve.service.WorryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+@RequestMapping("/worries")
+public class WorryController {
+
+    private final WorryService worryService;
+
+    @PostMapping
+    public BasicResponse<CreateWorryResponse> createWorry(@RequestHeader Long userId,
+                                                          @RequestBody @Valid CreateWorryRequest request){
+
+        CreateWorryResponse response = worryService.createWorry(userId, request);
+
+        return BasicResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/weve/domain/User.java
+++ b/src/main/java/com/weve/domain/User.java
@@ -2,8 +2,7 @@ package com.weve.domain;
 
 import com.weve.domain.enums.Language;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.Date;
 import java.util.List;
@@ -11,6 +10,10 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/weve/domain/Worry.java
+++ b/src/main/java/com/weve/domain/Worry.java
@@ -3,8 +3,7 @@ package com.weve.domain;
 import com.weve.domain.enums.WorryCategory;
 import com.weve.domain.enums.WorryStatus;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +11,9 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Worry {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/weve/dto/request/CreateWorryRequest.java
+++ b/src/main/java/com/weve/dto/request/CreateWorryRequest.java
@@ -1,0 +1,10 @@
+package com.weve.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CreateWorryRequest {
+
+    private String content;
+    private boolean isAnonymous;
+}

--- a/src/main/java/com/weve/dto/request/CreateWorryRequest.java
+++ b/src/main/java/com/weve/dto/request/CreateWorryRequest.java
@@ -1,8 +1,10 @@
 package com.weve.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class CreateWorryRequest {
 
     private String content;

--- a/src/main/java/com/weve/dto/response/CreateWorryResponse.java
+++ b/src/main/java/com/weve/dto/response/CreateWorryResponse.java
@@ -1,0 +1,14 @@
+package com.weve.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateWorryResponse {
+    private Long worryId;
+}

--- a/src/main/java/com/weve/repository/UserRepository.java
+++ b/src/main/java/com/weve/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.weve.repository;
+
+import com.weve.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/weve/repository/WorryRepository.java
+++ b/src/main/java/com/weve/repository/WorryRepository.java
@@ -1,0 +1,7 @@
+package com.weve.repository;
+
+import com.weve.domain.Worry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorryRepository extends JpaRepository<Worry, Long> {
+}

--- a/src/main/java/com/weve/service/UserService.java
+++ b/src/main/java/com/weve/service/UserService.java
@@ -1,0 +1,25 @@
+package com.weve.service;
+
+import com.weve.common.api.exception.GeneralException;
+import com.weve.common.api.payload.code.status.ErrorStatus;
+import com.weve.domain.User;
+import com.weve.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    // id로 유저 검색
+    public User findById(Long memberId) {
+        return userRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -1,0 +1,51 @@
+package com.weve.service;
+
+import com.weve.common.api.exception.GeneralException;
+import com.weve.common.api.payload.code.status.ErrorStatus;
+import com.weve.domain.User;
+import com.weve.domain.Worry;
+import com.weve.dto.request.CreateWorryRequest;
+import com.weve.dto.response.CreateWorryResponse;
+import com.weve.repository.WorryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class WorryService {
+
+    private final WorryRepository worryRepository;
+    private final UserService userService;
+
+    /**
+     * 고민 작성하기
+     */
+    @Transactional
+    public CreateWorryResponse createWorry(Long userId, CreateWorryRequest request) {
+        log.info("[고민 작성] userId={}", userId);
+
+        User user = userService.findById(userId);
+
+        // 유저 타입 검사(청년만 고민 작성 가능)
+        if(user.isSenior()) {
+            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
+        }
+
+        Worry newWorry = Worry.builder()
+                .junior(user)
+                .content(request.getContent())
+                .isAnonymous(request.isAnonymous())
+                .build();
+
+        worryRepository.save(newWorry);
+        log.info("생성된 고민 ID: {}", newWorry.getId());
+
+        return CreateWorryResponse.builder()
+                .worryId(newWorry.getId())
+                .build();
+    }
+}

--- a/src/test/java/com/weve/WeveApplicationTests.java
+++ b/src/test/java/com/weve/WeveApplicationTests.java
@@ -2,8 +2,10 @@ package com.weve;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class WeveApplicationTests {
 
     @Test

--- a/src/test/java/com/weve/service/WorryServiceTest.java
+++ b/src/test/java/com/weve/service/WorryServiceTest.java
@@ -1,0 +1,62 @@
+package com.weve.service;
+
+import com.weve.domain.User;
+import com.weve.domain.Worry;
+import com.weve.dto.request.CreateWorryRequest;
+import com.weve.dto.response.CreateWorryResponse;
+import com.weve.repository.UserRepository;
+import com.weve.repository.WorryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class WorryServiceTest {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private WorryRepository worryRepository;
+    @Autowired private WorryService worryService;
+
+    private static final Logger logger = LoggerFactory.getLogger(WorryServiceTest.class);
+
+    @Test
+    @DisplayName("고민 작성 성공")
+    void createWorryTest() {
+
+        // given
+        User user = User.builder().name("주니어").isSenior(false).build();
+        userRepository.save(user);
+
+        CreateWorryRequest request = CreateWorryRequest.builder()
+                .content("content")
+                .isAnonymous(false)
+                .build();
+
+        // when
+        CreateWorryResponse response = worryService.createWorry(user.getId(), request);
+
+        // then
+        assertNotNull(response);
+        assertEquals(user.getId(), response.getWorryId());
+
+        Optional<Worry> savedWorry = worryRepository.findById(response.getWorryId());
+        assertTrue(savedWorry.isPresent());
+        assertEquals("content", savedWorry.get().getContent());
+        assertFalse(savedWorry.get().isAnonymous());
+        assertEquals(user.getId(), savedWorry.get().getJunior().getId());
+    }
+
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #1 

## 💻 작업 내용
- [x] API Payload(에러 핸들러, 응답 양식) 설정
- [x] 고민 작성하기 API 구현
- [x] 고민 작성 테스트 코드 작성

## ✅ PR Point
- payload 사용하는 것까지 반영하는게 좋을 것 같아서 고민 작성하기 API 구현도 포함해서 PR 올리게 되었습니다.
- payload 사용법은 노션에 기록해 두었습니다.
- H2 DB(테스트용)에서 user 키워드가 예약어로 지정되어 있어서 user 테이블 생성이 안되는 문제가 발생하여 "users"로 테이블명 변경했습니다. ```@Table(name = "users")```
- application-test.yml 추가 후 노션 YML 페이지에 반영했습니다.
- JWT 구현 전으로, 우선은 userId를 헤더로 직접 받아오는 방식으로 구현했습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
<img width="727" alt="스크린샷 2025-02-06 오후 10 44 17" src="https://github.com/user-attachments/assets/7db2ee59-345d-4894-bd3d-667279f28158" />
<img width="631" alt="스크린샷 2025-02-06 오후 10 51 56" src="https://github.com/user-attachments/assets/e1124505-dcd8-46eb-9c9b-2a0d5923759c" />

