### PR TITLE
[WORRY] 고민 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/weve/controller/WorryController.java
+++ b/src/main/java/com/weve/controller/WorryController.java
@@ -37,7 +37,7 @@ public class WorryController {
      */
     @GetMapping
     public BasicResponse<?> getWorries(@RequestHeader Long userId,
-                                       @RequestParam String userType) {
+                                       @RequestParam("usertype") String userType) {
 
         if (userType.equals("junior")) {
             // JUNIOR ver
@@ -45,7 +45,8 @@ public class WorryController {
             return BasicResponse.onSuccess(response);
         } else {
             // SENIOR ver
-            return BasicResponse.onSuccess();
+            GetWorriesResponse.seniorVer response = worryService.getWorriesForSenior(userId);
+            return BasicResponse.onSuccess(response);
         }
     }
 }

--- a/src/main/java/com/weve/controller/WorryController.java
+++ b/src/main/java/com/weve/controller/WorryController.java
@@ -3,6 +3,7 @@ package com.weve.controller;
 import com.weve.common.api.payload.BasicResponse;
 import com.weve.dto.request.CreateWorryRequest;
 import com.weve.dto.response.CreateWorryResponse;
+import com.weve.dto.response.GetWorriesResponse;
 import com.weve.service.WorryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,9 @@ public class WorryController {
 
     private final WorryService worryService;
 
+    /**
+     * 고민 작성하기
+     */
     @PostMapping
     public BasicResponse<CreateWorryResponse> createWorry(@RequestHeader Long userId,
                                                           @RequestBody @Valid CreateWorryRequest request){
@@ -28,5 +32,22 @@ public class WorryController {
         CreateWorryResponse response = worryService.createWorry(userId, request);
 
         return BasicResponse.onSuccess(response);
+    }
+
+    /**
+     * 고민 목록 조회
+     */
+    @GetMapping
+    public BasicResponse<?> getWorries(@RequestHeader Long userId,
+                                       @RequestParam String userType) {
+
+        if (userType.equals("junior")) {
+            // JUNIOR ver
+            GetWorriesResponse.juniorVer response = worryService.getWorriesForJunior(userId);
+            return BasicResponse.onSuccess(response);
+        } else {
+            // SENIOR ver
+            return BasicResponse.onSuccess();
+        }
     }
 }

--- a/src/main/java/com/weve/controller/WorryController.java
+++ b/src/main/java/com/weve/controller/WorryController.java
@@ -11,8 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
-
 @RestController
 @RequiredArgsConstructor
 @Validated

--- a/src/main/java/com/weve/domain/Answer.java
+++ b/src/main/java/com/weve/domain/Answer.java
@@ -2,12 +2,13 @@ package com.weve.domain;
 
 import com.weve.domain.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Answer extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/weve/domain/Appreciate.java
+++ b/src/main/java/com/weve/domain/Appreciate.java
@@ -2,12 +2,13 @@ package com.weve.domain;
 
 import com.weve.domain.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Appreciate extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/weve/domain/CategoryMapping.java
+++ b/src/main/java/com/weve/domain/CategoryMapping.java
@@ -18,11 +18,11 @@ public class CategoryMapping extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "worry_id")
     private Worry worry;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "senior_id")
     private User senior;
 

--- a/src/main/java/com/weve/domain/MatchingInfo.java
+++ b/src/main/java/com/weve/domain/MatchingInfo.java
@@ -1,30 +1,19 @@
 package com.weve.domain;
 
-import com.weve.domain.common.BaseEntity;
 import com.weve.domain.enums.HardshipCategory;
 import com.weve.domain.enums.JobCategory;
 import com.weve.domain.enums.ValueCategory;
-import jakarta.persistence.*;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.*;
 
-@Entity
 @Getter
-@Setter
 @Builder
+@Embeddable
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CategoryMapping extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @OneToOne
-    @JoinColumn(name = "worry_id")
-    private Worry worry;
-
-    @OneToOne
-    @JoinColumn(name = "senior_id")
-    private User senior;
+public class MatchingInfo {
 
     @Enumerated(EnumType.STRING)
     private JobCategory job;

--- a/src/main/java/com/weve/domain/User.java
+++ b/src/main/java/com/weve/domain/User.java
@@ -2,6 +2,7 @@ package com.weve.domain;
 
 import com.weve.domain.common.BaseEntity;
 import com.weve.domain.enums.Language;
+import com.weve.domain.enums.UserType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -31,7 +32,8 @@ public class User extends BaseEntity {
 
     private String phoneNumber;
 
-    private boolean isSenior;
+    @Enumerated(EnumType.STRING)
+    private UserType userType;
 
     @OneToMany(mappedBy = "junior", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Worry> worries;

--- a/src/main/java/com/weve/domain/User.java
+++ b/src/main/java/com/weve/domain/User.java
@@ -39,6 +39,6 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "senior", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Answer> answers;
 
-    @OneToMany(mappedBy = "senior", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<CategoryMapping> categoryMappings;
+    @OneToOne(mappedBy = "senior", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private CategoryMapping categoryMapping;
 }

--- a/src/main/java/com/weve/domain/User.java
+++ b/src/main/java/com/weve/domain/User.java
@@ -41,6 +41,6 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "senior", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Answer> answers;
 
-    @OneToOne(mappedBy = "senior", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private CategoryMapping categoryMapping;
+    @Embedded
+    private MatchingInfo matchingInfo;
 }

--- a/src/main/java/com/weve/domain/User.java
+++ b/src/main/java/com/weve/domain/User.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/weve/domain/Worry.java
+++ b/src/main/java/com/weve/domain/Worry.java
@@ -40,8 +40,8 @@ public class Worry extends BaseEntity {
 
     private String mp4;
 
-    @OneToOne(mappedBy = "worry", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private CategoryMapping categoryMapping;
+    @Embedded
+    private MatchingInfo matchingInfo;
 
     @OneToMany(mappedBy = "worry", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Answer> answers;

--- a/src/main/java/com/weve/domain/Worry.java
+++ b/src/main/java/com/weve/domain/Worry.java
@@ -28,6 +28,8 @@ public class Worry extends BaseEntity {
     @Column(length = 300)
     private String content;
 
+    private String title;
+
     @Enumerated(EnumType.STRING)
     private WorryCategory category;
 

--- a/src/main/java/com/weve/domain/Worry.java
+++ b/src/main/java/com/weve/domain/Worry.java
@@ -40,6 +40,9 @@ public class Worry extends BaseEntity {
 
     private String mp4;
 
+    @OneToOne(mappedBy = "worry", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private CategoryMapping categoryMapping;
+
     @OneToMany(mappedBy = "worry", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Answer> answers;
 

--- a/src/main/java/com/weve/domain/Worry.java
+++ b/src/main/java/com/weve/domain/Worry.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/weve/domain/enums/UserType.java
+++ b/src/main/java/com/weve/domain/enums/UserType.java
@@ -1,0 +1,6 @@
+package com.weve.domain.enums;
+
+public enum UserType {
+    JUNIOR,
+    SENIOR
+}

--- a/src/main/java/com/weve/dto/response/GetWorriesResponse.java
+++ b/src/main/java/com/weve/dto/response/GetWorriesResponse.java
@@ -1,0 +1,38 @@
+package com.weve.dto.response;
+
+import com.weve.domain.enums.WorryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class GetWorriesResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class juniorVer {
+        private List<WorryForJunior> worryList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WorryForJunior {
+        private Long worryId;
+        private String title;
+        private WorryStatus status;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class seniorVer {
+
+    }
+}

--- a/src/main/java/com/weve/dto/response/GetWorriesResponse.java
+++ b/src/main/java/com/weve/dto/response/GetWorriesResponse.java
@@ -33,6 +33,26 @@ public class GetWorriesResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class seniorVer {
+        private WorryCategoryInfo worryList;
+    }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WorryCategoryInfo {
+        private List<WorryForSenior> career;
+        private List<WorryForSenior> love;
+        private List<WorryForSenior> relationship;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WorryForSenior {
+        private Long worryId;
+        private String author;
+        private String title;
     }
 }

--- a/src/main/java/com/weve/repository/CategoryMappingRepository.java
+++ b/src/main/java/com/weve/repository/CategoryMappingRepository.java
@@ -1,7 +1,0 @@
-package com.weve.repository;
-
-import com.weve.domain.CategoryMapping;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CategoryMappingRepository extends JpaRepository<CategoryMapping, Long> {
-}

--- a/src/main/java/com/weve/repository/WorryRepository.java
+++ b/src/main/java/com/weve/repository/WorryRepository.java
@@ -9,31 +9,31 @@ import java.util.List;
 public interface WorryRepository extends JpaRepository<Worry, Long> {
 
     // 3개 조건 모두 일치
-    List<Worry> findByCategoryMapping_JobAndCategoryMapping_ValueAndCategoryMapping_HardshipAndCategory(
+    List<Worry> findByMatchingInfo_JobAndMatchingInfo_ValueAndMatchingInfo_HardshipAndCategory(
             JobCategory job, ValueCategory value, HardshipCategory hardship, WorryCategory category);
 
     // 2개 조건: job, value
-    List<Worry> findByCategoryMapping_JobAndCategoryMapping_ValueAndCategory(
+    List<Worry> findByMatchingInfo_JobAndMatchingInfo_ValueAndCategory(
             JobCategory job, ValueCategory value, WorryCategory category);
 
     // 2개 조건: job, hardship
-    List<Worry> findByCategoryMapping_JobAndCategoryMapping_HardshipAndCategory(
+    List<Worry> findByMatchingInfo_JobAndMatchingInfo_HardshipAndCategory(
             JobCategory job, HardshipCategory hardship, WorryCategory category);
 
     // 2개 조건: value, hardship
-    List<Worry> findByCategoryMapping_ValueAndCategoryMapping_HardshipAndCategory(
+    List<Worry> findByMatchingInfo_ValueAndMatchingInfo_HardshipAndCategory(
             ValueCategory value, HardshipCategory hardship, WorryCategory category);
 
     // 1개 조건: job
-    List<Worry> findByCategoryMapping_JobAndCategory(
+    List<Worry> findByMatchingInfo_JobAndCategory(
             JobCategory job, WorryCategory category);
 
     // 1개 조건: value
-    List<Worry> findByCategoryMapping_ValueAndCategory(
+    List<Worry> findByMatchingInfo_ValueAndCategory(
             ValueCategory value, WorryCategory category);
 
     // 1개 조건: hardship
-    List<Worry> findByCategoryMapping_HardshipAndCategory(
+    List<Worry> findByMatchingInfo_HardshipAndCategory(
             HardshipCategory hardship, WorryCategory category);
 
     // 0개 조건

--- a/src/main/java/com/weve/repository/WorryRepository.java
+++ b/src/main/java/com/weve/repository/WorryRepository.java
@@ -1,7 +1,41 @@
 package com.weve.repository;
 
 import com.weve.domain.Worry;
+import com.weve.domain.enums.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface WorryRepository extends JpaRepository<Worry, Long> {
+
+    // 3개 조건 모두 일치
+    List<Worry> findByCategoryMapping_JobAndCategoryMapping_ValueAndCategoryMapping_HardshipAndCategory(
+            JobCategory job, ValueCategory value, HardshipCategory hardship, WorryCategory category);
+
+    // 2개 조건: job, value
+    List<Worry> findByCategoryMapping_JobAndCategoryMapping_ValueAndCategory(
+            JobCategory job, ValueCategory value, WorryCategory category);
+
+    // 2개 조건: job, hardship
+    List<Worry> findByCategoryMapping_JobAndCategoryMapping_HardshipAndCategory(
+            JobCategory job, HardshipCategory hardship, WorryCategory category);
+
+    // 2개 조건: value, hardship
+    List<Worry> findByCategoryMapping_ValueAndCategoryMapping_HardshipAndCategory(
+            ValueCategory value, HardshipCategory hardship, WorryCategory category);
+
+    // 1개 조건: job
+    List<Worry> findByCategoryMapping_JobAndCategory(
+            JobCategory job, WorryCategory category);
+
+    // 1개 조건: value
+    List<Worry> findByCategoryMapping_ValueAndCategory(
+            ValueCategory value, WorryCategory category);
+
+    // 1개 조건: hardship
+    List<Worry> findByCategoryMapping_HardshipAndCategory(
+            HardshipCategory hardship, WorryCategory category);
+
+    // 0개 조건
+    List<Worry> findByCategory(WorryCategory category);
 }

--- a/src/main/java/com/weve/service/GeminiService.java
+++ b/src/main/java/com/weve/service/GeminiService.java
@@ -103,4 +103,32 @@ public class GeminiService {
 
         return WorryCategory.valueOf(result.trim());
     }
+
+    /**
+     * 10~15자 내 1줄 요약(고민 내용 분석 후, 제목 생성)
+     */
+    public String summarize(String prompt) {
+        String requestUrl = apiUrl + "?key=" + geminiApiKey;
+
+        // 프롬프트 확장
+        String extendedPrompt = prompt + "\n\n"
+                + "Summarize the given text into a single sentence in a natural speaking tone, using polite language"
+                + "Keep it between 10 to 15 characters."
+                + "Return only the summary without any additional text and without a period at the end";
+
+        // Gemini 요청 생성
+        GeminiRequest request = GeminiRequest.builder()
+                .contents(List.of(GeminiRequest.Content.builder()
+                        .parts(List.of(GeminiRequest.Part.builder().text(extendedPrompt).build()))
+                        .build()))
+                .build();
+
+        // Gemini 응답 처리
+        GeminiResponse response = restTemplate.postForObject(requestUrl, request, GeminiResponse.class);
+        String result = response.getCandidates().get(0).getContent().getParts().get(0).getText();
+
+        log.info("Gemini 응답: {}", result);
+
+        return result.trim();
+    }
 }

--- a/src/main/java/com/weve/service/GeminiService.java
+++ b/src/main/java/com/weve/service/GeminiService.java
@@ -64,7 +64,7 @@ public class GeminiService {
         String result = response.getCandidates().get(0).getContent().getParts().get(0).getText();
         String cleanedResult = result.replaceAll("^```json|```$", "").trim(); // 마크다운 문법 제거 후, 순수 JSON만 반환
 
-        log.info("Gemini 응답: {}", cleanedResult);
+        log.info("추출된 매칭 정보: {}", cleanedResult);
 
         // JSON 문자열을 DTO로 변환
         ObjectMapper objectMapper = new ObjectMapper();
@@ -99,7 +99,7 @@ public class GeminiService {
         GeminiResponse response = restTemplate.postForObject(requestUrl, request, GeminiResponse.class);
         String result = response.getCandidates().get(0).getContent().getParts().get(0).getText();
 
-        log.info("Gemini 응답: {}", result);
+        log.info("추출된 고민 카테고리: {}", result);
 
         return WorryCategory.valueOf(result.trim());
     }

--- a/src/main/java/com/weve/service/UserService.java
+++ b/src/main/java/com/weve/service/UserService.java
@@ -9,6 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.weve.domain.enums.UserType.JUNIOR;
+import static com.weve.domain.enums.UserType.SENIOR;
+
 @Slf4j
 @Service
 @Transactional(readOnly = true)
@@ -21,5 +24,19 @@ public class UserService {
     public User findById(Long memberId) {
         return userRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    // 주니어인지 검사
+    public void checkIfJunior(User user) {
+        if(user.getUserType() != JUNIOR) {
+            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
+        }
+    }
+
+    // 시니어인지 검사
+    public void checkIfSenior(User user) {
+        if(user.getUserType() != SENIOR) {
+            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
+        }
     }
 }

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -1,7 +1,5 @@
 package com.weve.service;
 
-import com.weve.common.api.exception.GeneralException;
-import com.weve.common.api.payload.code.status.ErrorStatus;
 import com.weve.domain.CategoryMapping;
 import com.weve.domain.User;
 import com.weve.domain.Worry;
@@ -40,9 +38,7 @@ public class WorryService {
         User user = userService.findById(userId);
 
         // 유저 타입 검사(청년만 고민 작성 가능)
-        if(user.isSenior()) {
-            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
-        }
+        userService.checkIfJunior(user);
 
         // WorryCategory 추출
         WorryCategory worryCategory = geminiService.analyzeWorry(request.getContent());
@@ -92,9 +88,7 @@ public class WorryService {
         User user = userService.findById(userId);
 
         // 유저 타입 검사
-        if(user.isSenior()) {
-            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
-        }
+        userService.checkIfJunior(user);
 
         List<GetWorriesResponse.WorryForJunior> worries = user.getWorries().stream()
                 .map(worry -> {
@@ -119,15 +113,13 @@ public class WorryService {
         User user = userService.findById(userId);
 
         // 유저 타입 검사
-        if(!user.isSenior()) {
-            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
-        }
+        userService.checkIfSenior(user);
 
         // User의 CategoryMapping에서 카테고리 정보 가져오기
         CategoryMapping categoryMapping = user.getCategoryMapping();
         JobCategory job = categoryMapping.getJob();
         ValueCategory value = categoryMapping.getValue();
-        HardshipCategory hardship = categoryMapping.getHardship();
+        HardshipCategory hardship = categoryMapping.getHardship();;
 
         // 고민 목록 조회
         List<Worry> careerWorries = getMatchingWorries(job, value, hardship, WorryCategory.CAREER);

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -18,9 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -50,10 +48,14 @@ public class WorryService {
         // WorryCategory 추출
         WorryCategory worryCategory = geminiService.analyzeWorry(request.getContent());
 
+        // 제목 생성(1줄 요약)
+        String title = geminiService.summarize(request.getContent());
+
         // Worry 데이터 생성 및 저장
         Worry newWorry = Worry.builder()
                 .junior(user)
                 .content(request.getContent())
+                .title(title)
                 .isAnonymous(request.isAnonymous())
                 .category(worryCategory)
                 .status(WorryStatus.WAITING)

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -123,7 +123,7 @@ public class WorryService {
                 .map(worry -> {
                     return GetWorriesResponse.WorryForSenior.builder()
                             .worryId(worry.getId())
-                            .author(worry.getJunior().getName())
+                            .author(worry.isAnonymous() ? "위명의 위비" : worry.getJunior().getName())
                             .title(worry.getTitle())
                             .build();
                 })
@@ -133,7 +133,7 @@ public class WorryService {
                 .map(worry -> {
                     return GetWorriesResponse.WorryForSenior.builder()
                             .worryId(worry.getId())
-                            .author(worry.getJunior().getName())
+                            .author(worry.isAnonymous() ? "위명의 위비" : worry.getJunior().getName())
                             .title(worry.getTitle())
                             .build();
                 })
@@ -143,7 +143,7 @@ public class WorryService {
                 .map(worry -> {
                     return GetWorriesResponse.WorryForSenior.builder()
                             .worryId(worry.getId())
-                            .author(worry.getJunior().getName())
+                            .author(worry.isAnonymous() ? "위명의 위비" : worry.getJunior().getName())
                             .title(worry.getTitle())
                             .build();
                 })

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -10,12 +10,17 @@ import com.weve.domain.enums.WorryStatus;
 import com.weve.dto.gemini.ExtractedCategoriesFromText;
 import com.weve.dto.request.CreateWorryRequest;
 import com.weve.dto.response.CreateWorryResponse;
+import com.weve.dto.response.GetWorriesResponse;
 import com.weve.repository.CategoryMappingRepository;
 import com.weve.repository.WorryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -74,5 +79,32 @@ public class WorryService {
         return CreateWorryResponse.builder()
                 .worryId(newWorry.getId())
                 .build();
+    }
+
+    /**
+     * 고민 목록 조회(JUNIOR ver)
+     */
+    public GetWorriesResponse.juniorVer getWorriesForJunior(Long userId) {
+
+        log.info("[고민 목록 조회(JUNIOR ver)] userId={}", userId);
+
+        User user = userService.findById(userId);
+
+        // 유저 타입 검사
+        if(user.isSenior()) {
+            throw new GeneralException(ErrorStatus.INVALID_USER_TYPE);
+        }
+
+        List<GetWorriesResponse.WorryForJunior> worries = user.getWorries().stream()
+                .map(worry -> {
+                    return GetWorriesResponse.WorryForJunior.builder()
+                            .worryId(worry.getId())
+                            .title(worry.getTitle())
+                            .status(worry.getStatus())
+                            .build();
+                })
+                .toList();
+
+        return GetWorriesResponse.juniorVer.builder().worryList(worries).build();
     }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #5 

## 💻 작업 내용
- [x] 고민 목록 조회 API JUNIOR ver 구현
- [x] 고민 목록 조회 API SENIOR ver 구현

## ✅ PR Point
- 매칭 기능 구현 과정에서 쿼리가 너무 많이 발생해서 매칭 관련 정보를 별도 테이블(category mapping)로 관리하는 대신, 임베디드 타입(MatchingInfo)으로 변경하여 user와 worry 내부에서 각각 관리하도록 수정했습니다.(테스트 통해서 쿼리 수 줄어든 것까지 확인)
- Entity에서 Setter 제거 : '불명확한 사용 의도', '무분별한 변경으로 인한 객체 일관성 보장 어려움' 등의 이유로 인해 Entity 단에서 setter 사용은 지양하는게 좋지 않을까 해서 수정했습니다. 생성시에는 Builder 패턴 사용, 수정이 필요한 경우에는 별도의 update 메소드를 추가하는 방안 등이 있는데 더 나은 방법이 있으면 의견 부탁드립니다:) 
(참고 : https://velog.io/@langoustine/setter-%EC%A7%80%EC%96%91-%EC%9D%B4%EC%9C%A0)

## ☀️ 스크린샷 / GIF / 화면 녹화

1️⃣ JUNIOR 고민 목록 조회
```java
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "worryList": [
            {
                "worryId": 1,
                "title": "취업 길이 막막합니다",
                "status": "WAITING"
            }
        ]
    }
}
```

2️⃣ SENIOR 고민 목록 조회
```java
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "worryList": {
            "career": [
                {
                    "worryId": 1,
                    "author": "짱구",
                    "title": "취업 길이 막막합니다"
                }
            ],
            "love": [],
            "relationship": []
        }
    }
}
```