### PR TITLE
[WORRY] 감사인사 상세 조회 JUNIOR ver

### DIFF
--- a/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
@@ -25,7 +25,10 @@ public enum ErrorStatus implements BaseErrorCode {
     WORRY_NOT_FOUND(HttpStatus.NOT_FOUND, "WORRY400", "존재하지 않는 고민 정보입니다."),
     WORRY_ALREADY_ANSWERED(HttpStatus.CONFLICT, "WORRY401", "이미 답변이 달린 고민입니다."),
     WORRY_UNANSWERED(HttpStatus.NOT_FOUND, "WORRY402", "답변이 달리지 않은 고민입니다."),
-    WORRY_NOT_MINE(HttpStatus.CONFLICT, "WORRY403", "본인이 작성한 고민이 아닙니다.");
+    WORRY_NOT_MINE(HttpStatus.CONFLICT, "WORRY403", "본인이 작성한 고민이 아닙니다."),
+
+    // ANSWER
+    ANSWER_NOT_MINE(HttpStatus.CONFLICT, "ANSWER400", "본인이 작성한 답변이 아닙니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
@@ -26,8 +26,9 @@ public enum ErrorStatus implements BaseErrorCode {
     WORRY_ALREADY_ANSWERED(HttpStatus.CONFLICT, "WORRY401", "이미 답변이 달린 고민입니다."),
     WORRY_UNANSWERED(HttpStatus.NOT_FOUND, "WORRY402", "답변이 달리지 않은 고민입니다."),
     WORRY_NOT_MINE(HttpStatus.CONFLICT, "WORRY403", "본인이 작성한 고민이 아닙니다."),
+    WORRY_APPRECIATE_NOT_FOUND(HttpStatus.NOT_FOUND, "WORRY404", "해당 고민의 답변에 대한 감사 인사가 존재하지 않습니다."),
 
-    // ANSWER
+    // Answer
     ANSWER_NOT_MINE(HttpStatus.CONFLICT, "ANSWER400", "본인이 작성한 답변이 아닙니다.");
 
 

--- a/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
@@ -22,7 +22,9 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_USER_TYPE(HttpStatus.CONFLICT, "USER401", "적절하지 않은 유저 타입입니다."),
 
     // Worry
-    WORRY_NOT_FOUND(HttpStatus.NOT_FOUND, "WORRY400", "존재하지 않는 고민 정보입니다.");
+    WORRY_NOT_FOUND(HttpStatus.NOT_FOUND, "WORRY400", "존재하지 않는 고민 정보입니다."),
+    WORRY_ALREADY_ANSWERED(HttpStatus.CONFLICT, "WORRY401", "이미 답변이 달린 고민입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/weve/common/api/payload/code/status/ErrorStatus.java
@@ -23,7 +23,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Worry
     WORRY_NOT_FOUND(HttpStatus.NOT_FOUND, "WORRY400", "존재하지 않는 고민 정보입니다."),
-    WORRY_ALREADY_ANSWERED(HttpStatus.CONFLICT, "WORRY401", "이미 답변이 달린 고민입니다.");
+    WORRY_ALREADY_ANSWERED(HttpStatus.CONFLICT, "WORRY401", "이미 답변이 달린 고민입니다."),
+    WORRY_UNANSWERED(HttpStatus.NOT_FOUND, "WORRY402", "답변이 달리지 않은 고민입니다."),
+    WORRY_NOT_MINE(HttpStatus.CONFLICT, "WORRY403", "본인이 작성한 고민이 아닙니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/weve/controller/WorryController.java
+++ b/src/main/java/com/weve/controller/WorryController.java
@@ -3,10 +3,7 @@ package com.weve.controller;
 import com.weve.common.api.payload.BasicResponse;
 import com.weve.dto.request.CreateAnswerRequest;
 import com.weve.dto.request.CreateWorryRequest;
-import com.weve.dto.response.CreateWorryResponse;
-import com.weve.dto.response.GetAnswerResponse;
-import com.weve.dto.response.GetWorriesResponse;
-import com.weve.dto.response.GetWorryResponse;
+import com.weve.dto.response.*;
 import com.weve.service.AnswerService;
 import com.weve.service.WorryService;
 import jakarta.validation.Valid;
@@ -101,6 +98,15 @@ public class WorryController {
     @GetMapping("/{worryId}/answer/senior")
     public BasicResponse<GetAnswerResponse.seniorVer> getAnswerForSenior(@RequestHeader Long userId, @PathVariable Long worryId) {
         GetAnswerResponse.seniorVer response = worryService.getAnswerForSenior(userId, worryId);
+        return BasicResponse.onSuccess(response);
+    }
+
+    /**
+     * 답변 상세 조회(JUNIOR ver)
+     */
+    @GetMapping("/{worryId}/appreciate/junior")
+    public BasicResponse<GetAppreciateResponse.juniorVer> getAppreciateForJunior(@RequestHeader Long userId, @PathVariable Long worryId) {
+        GetAppreciateResponse.juniorVer response = worryService.getAppreciateForJunior(userId, worryId);
         return BasicResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/weve/controller/WorryController.java
+++ b/src/main/java/com/weve/controller/WorryController.java
@@ -4,6 +4,7 @@ import com.weve.common.api.payload.BasicResponse;
 import com.weve.dto.request.CreateAnswerRequest;
 import com.weve.dto.request.CreateWorryRequest;
 import com.weve.dto.response.CreateWorryResponse;
+import com.weve.dto.response.GetAnswerResponse;
 import com.weve.dto.response.GetWorriesResponse;
 import com.weve.dto.response.GetWorryResponse;
 import com.weve.service.AnswerService;
@@ -58,7 +59,7 @@ public class WorryController {
      * 고민 상세 조회(JUNIOR ver)
      */
     @GetMapping("/{worryId}/junior")
-    public BasicResponse<?> getWorryForJunior(@RequestHeader Long userId, @PathVariable Long worryId) {
+    public BasicResponse<GetWorryResponse.juniorVer> getWorryForJunior(@RequestHeader Long userId, @PathVariable Long worryId) {
         GetWorryResponse.juniorVer response = worryService.getWorryForJunior(userId, worryId);
         return BasicResponse.onSuccess(response);
     }
@@ -67,7 +68,7 @@ public class WorryController {
      * 고민 상세 조회(SENIOR ver)
      */
     @GetMapping("/{worryId}/senior")
-    public BasicResponse<?> getWorryForSenior(@RequestHeader Long userId, @PathVariable Long worryId) {
+    public BasicResponse<GetWorryResponse.seniorVer> getWorryForSenior(@RequestHeader Long userId, @PathVariable Long worryId) {
         GetWorryResponse.seniorVer response = worryService.getWorryForSenior(userId, worryId);
         return BasicResponse.onSuccess(response);
     }
@@ -83,5 +84,14 @@ public class WorryController {
         answerService.createAnswer(userId, worryId, request);
 
         return BasicResponse.onSuccess(null);
+    }
+
+    /**
+     * 답변 상세 조회(JUNIOR ver)
+     */
+    @GetMapping("/{worryId}/answer/junior")
+    public BasicResponse<GetAnswerResponse.juniorVer> getAnswerForJunior(@RequestHeader Long userId, @PathVariable Long worryId) {
+        GetAnswerResponse.juniorVer response = worryService.getAnswerForJunior(userId, worryId);
+        return BasicResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/weve/controller/WorryController.java
+++ b/src/main/java/com/weve/controller/WorryController.java
@@ -94,4 +94,13 @@ public class WorryController {
         GetAnswerResponse.juniorVer response = worryService.getAnswerForJunior(userId, worryId);
         return BasicResponse.onSuccess(response);
     }
+
+    /**
+     * 답변 상세 조회(SENIOR ver)
+     */
+    @GetMapping("/{worryId}/answer/senior")
+    public BasicResponse<GetAnswerResponse.seniorVer> getAnswerForSenior(@RequestHeader Long userId, @PathVariable Long worryId) {
+        GetAnswerResponse.seniorVer response = worryService.getAnswerForSenior(userId, worryId);
+        return BasicResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/weve/controller/WorryController.java
+++ b/src/main/java/com/weve/controller/WorryController.java
@@ -1,10 +1,12 @@
 package com.weve.controller;
 
 import com.weve.common.api.payload.BasicResponse;
+import com.weve.dto.request.CreateAnswerRequest;
 import com.weve.dto.request.CreateWorryRequest;
 import com.weve.dto.response.CreateWorryResponse;
 import com.weve.dto.response.GetWorriesResponse;
 import com.weve.dto.response.GetWorryResponse;
+import com.weve.service.AnswerService;
 import com.weve.service.WorryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class WorryController {
 
     private final WorryService worryService;
+    private final AnswerService answerService;
 
     /**
      * 고민 작성하기
@@ -67,5 +70,18 @@ public class WorryController {
     public BasicResponse<?> getWorryForSenior(@RequestHeader Long userId, @PathVariable Long worryId) {
         GetWorryResponse.seniorVer response = worryService.getWorryForSenior(userId, worryId);
         return BasicResponse.onSuccess(response);
+    }
+
+    /**
+     * 답변 작성하기
+     */
+    @PostMapping("/{worryId}/answer")
+    public BasicResponse<?> createAnswer(@RequestHeader Long userId,
+                                                            @PathVariable Long worryId,
+                                                            @RequestBody @Valid CreateAnswerRequest request) {
+
+        answerService.createAnswer(userId, worryId, request);
+
+        return BasicResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/weve/domain/Answer.java
+++ b/src/main/java/com/weve/domain/Answer.java
@@ -22,7 +22,7 @@ public class Answer extends BaseEntity {
     @JoinColumn(name = "worry_id", nullable = false)
     private Worry worry;
 
-    private String answer;
+    private String content;
 
     private String imageUrl;
 

--- a/src/main/java/com/weve/domain/Answer.java
+++ b/src/main/java/com/weve/domain/Answer.java
@@ -24,5 +24,7 @@ public class Answer extends BaseEntity {
 
     private String answer;
 
-    private String letterImageUrl;
+    private String imageUrl;
+
+    private String audioUrl;
 }

--- a/src/main/java/com/weve/domain/Appreciate.java
+++ b/src/main/java/com/weve/domain/Appreciate.java
@@ -18,6 +18,8 @@ public class Appreciate extends BaseEntity {
     @JoinColumn(name = "worry_id", nullable = false)
     private Worry worry;
 
+    private String content;
+
     private String audioUrl;
 
     private boolean isRead;

--- a/src/main/java/com/weve/domain/Appreciate.java
+++ b/src/main/java/com/weve/domain/Appreciate.java
@@ -18,5 +18,7 @@ public class Appreciate extends BaseEntity {
     @JoinColumn(name = "worry_id", nullable = false)
     private Worry worry;
 
+    private String audioUrl;
+
     private boolean isRead;
 }

--- a/src/main/java/com/weve/domain/Worry.java
+++ b/src/main/java/com/weve/domain/Worry.java
@@ -43,9 +43,9 @@ public class Worry extends BaseEntity {
     private MatchingInfo matchingInfo;
 
     @OneToOne(mappedBy = "worry", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private Answer answers;
+    private Answer answer;
 
     @OneToOne(mappedBy = "worry", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private Appreciate appreciates;
+    private Appreciate appreciate;
 }
 

--- a/src/main/java/com/weve/dto/request/CreateAnswerRequest.java
+++ b/src/main/java/com/weve/dto/request/CreateAnswerRequest.java
@@ -1,0 +1,12 @@
+package com.weve.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateAnswerRequest {
+
+    private String content;
+    private String imageUrl;
+}

--- a/src/main/java/com/weve/dto/response/GetAnswerResponse.java
+++ b/src/main/java/com/weve/dto/response/GetAnswerResponse.java
@@ -18,4 +18,15 @@ public class GetAnswerResponse {
         private String author;
         private String imageUrl;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class seniorVer {
+        private String content;
+        private String audioUrl;
+        private String imageUrl;
+    }
 }

--- a/src/main/java/com/weve/dto/response/GetAnswerResponse.java
+++ b/src/main/java/com/weve/dto/response/GetAnswerResponse.java
@@ -1,5 +1,6 @@
 package com.weve.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,7 @@ public class GetAnswerResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class juniorVer {
         private String content;
         private String author;

--- a/src/main/java/com/weve/dto/response/GetAnswerResponse.java
+++ b/src/main/java/com/weve/dto/response/GetAnswerResponse.java
@@ -1,0 +1,19 @@
+package com.weve.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class GetAnswerResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class juniorVer {
+        private String content;
+        private String author;
+        private String imageUrl;
+    }
+}

--- a/src/main/java/com/weve/dto/response/GetAppreciateResponse.java
+++ b/src/main/java/com/weve/dto/response/GetAppreciateResponse.java
@@ -1,0 +1,20 @@
+package com.weve.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class GetAppreciateResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class juniorVer {
+        private String content;
+        private String author;
+    }
+}

--- a/src/main/java/com/weve/dto/response/GetWorriesResponse.java
+++ b/src/main/java/com/weve/dto/response/GetWorriesResponse.java
@@ -1,5 +1,6 @@
 package com.weve.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.weve.domain.enums.WorryStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,6 +15,7 @@ public class GetWorriesResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class juniorVer {
         private List<WorryForJunior> worryList;
     }
@@ -32,6 +34,7 @@ public class GetWorriesResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class seniorVer {
         private WorryCategoryInfo worryList;
     }
@@ -50,6 +53,7 @@ public class GetWorriesResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class WorryForSenior {
         private Long worryId;
         private String author;

--- a/src/main/java/com/weve/dto/response/GetWorryResponse.java
+++ b/src/main/java/com/weve/dto/response/GetWorryResponse.java
@@ -1,5 +1,6 @@
 package com.weve.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,7 @@ public class GetWorryResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class juniorVer {
         private String content;
         private String author;
@@ -20,6 +22,7 @@ public class GetWorryResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class seniorVer {
         private String author;
         private String nationality;

--- a/src/main/java/com/weve/repository/AnswerRepository.java
+++ b/src/main/java/com/weve/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.weve.repository;
+
+import com.weve.domain.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/com/weve/repository/WorryRepository.java
+++ b/src/main/java/com/weve/repository/WorryRepository.java
@@ -9,33 +9,33 @@ import java.util.List;
 public interface WorryRepository extends JpaRepository<Worry, Long> {
 
     // 3개 조건 모두 일치
-    List<Worry> findByMatchingInfo_JobAndMatchingInfo_ValueAndMatchingInfo_HardshipAndCategory(
+    List<Worry> findByMatchingInfo_JobAndMatchingInfo_ValueAndMatchingInfo_HardshipAndCategoryAndAnswerIsNull(
             JobCategory job, ValueCategory value, HardshipCategory hardship, WorryCategory category);
 
     // 2개 조건: job, value
-    List<Worry> findByMatchingInfo_JobAndMatchingInfo_ValueAndCategory(
+    List<Worry> findByMatchingInfo_JobAndMatchingInfo_ValueAndCategoryAndAnswerIsNull(
             JobCategory job, ValueCategory value, WorryCategory category);
 
     // 2개 조건: job, hardship
-    List<Worry> findByMatchingInfo_JobAndMatchingInfo_HardshipAndCategory(
+    List<Worry> findByMatchingInfo_JobAndMatchingInfo_HardshipAndCategoryAndAnswerIsNull(
             JobCategory job, HardshipCategory hardship, WorryCategory category);
 
     // 2개 조건: value, hardship
-    List<Worry> findByMatchingInfo_ValueAndMatchingInfo_HardshipAndCategory(
+    List<Worry> findByMatchingInfo_ValueAndMatchingInfo_HardshipAndCategoryAndAnswerIsNull(
             ValueCategory value, HardshipCategory hardship, WorryCategory category);
 
     // 1개 조건: job
-    List<Worry> findByMatchingInfo_JobAndCategory(
+    List<Worry> findByMatchingInfo_JobAndCategoryAndAnswerIsNull(
             JobCategory job, WorryCategory category);
 
     // 1개 조건: value
-    List<Worry> findByMatchingInfo_ValueAndCategory(
+    List<Worry> findByMatchingInfo_ValueAndCategoryAndAnswerIsNull(
             ValueCategory value, WorryCategory category);
 
     // 1개 조건: hardship
-    List<Worry> findByMatchingInfo_HardshipAndCategory(
+    List<Worry> findByMatchingInfo_HardshipAndCategoryAndAnswerIsNull(
             HardshipCategory hardship, WorryCategory category);
 
     // 0개 조건
-    List<Worry> findByCategory(WorryCategory category);
+    List<Worry> findByCategoryAndAnswerIsNull(WorryCategory category);
 }

--- a/src/main/java/com/weve/service/AnswerService.java
+++ b/src/main/java/com/weve/service/AnswerService.java
@@ -51,7 +51,7 @@ public class AnswerService {
         Answer newAnswer = Answer.builder()
                 .senior(user)
                 .worry(worry)
-                .answer(request.getContent())
+                .content(request.getContent())
                 .imageUrl(request.getImageUrl())
                 .audioUrl(audioUrl)
                 .build();

--- a/src/main/java/com/weve/service/AnswerService.java
+++ b/src/main/java/com/weve/service/AnswerService.java
@@ -1,0 +1,62 @@
+package com.weve.service;
+
+import com.weve.common.api.exception.GeneralException;
+import com.weve.common.api.payload.code.status.ErrorStatus;
+import com.weve.domain.Answer;
+import com.weve.domain.User;
+import com.weve.domain.Worry;
+import com.weve.dto.request.CreateAnswerRequest;
+import com.weve.repository.AnswerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AnswerService {
+
+    private final AnswerRepository answerRepository;
+    private final WorryService worryService;
+    private final UserService userService;
+    private final TtsService ttsService;
+    private final GcsService gcsService;
+
+    /**
+     * 답변 작성하기
+     */
+    @Transactional
+    public void createAnswer(Long userId, Long worryId, CreateAnswerRequest request) {
+        log.info("[답변 작성] userId={}, worryId={}", userId, worryId);
+
+        User user = userService.findById(userId);
+        Worry worry = worryService.findById(worryId);
+
+        // 이미 답변이 달린 고민일 경우, 에러 반환
+        if(worry.getAnswer() != null) {
+            throw new GeneralException(ErrorStatus.WORRY_ALREADY_ANSWERED);
+        }
+
+        // 유저 타입 검사(어르신만 답변 작성 가능)
+        userService.checkIfSenior(user);
+
+        // 고민 내용을 음성 파일로 변환(TTS)
+        byte[] audioData = ttsService.convertTextToSpeech(request.getContent());
+        String uuid = gcsService.uploadAudio(audioData);
+        String audioUrl = gcsService.processFile(uuid);
+
+        // Answer 데이터 생성 및 저장
+        Answer newAnswer = Answer.builder()
+                .senior(user)
+                .worry(worry)
+                .answer(request.getContent())
+                .imageUrl(request.getImageUrl())
+                .audioUrl(audioUrl)
+                .build();
+
+        answerRepository.save(newAnswer);
+        log.info("생성된 답변 ID: {}", newAnswer.getId());
+    }
+}

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -224,14 +224,14 @@ public class WorryService {
     // 매칭 고민 목록 조회
     private List<Worry> getMatchingWorries(JobCategory job, ValueCategory value, HardshipCategory hardship, WorryCategory category) {
         // 3개 조건 모두 일치하는 Worry들
-        List<Worry> threeMatching = worryRepository.findByMatchingInfo_JobAndMatchingInfo_ValueAndMatchingInfo_HardshipAndCategory(job, value, hardship, category);
+        List<Worry> threeMatching = worryRepository.findByMatchingInfo_JobAndMatchingInfo_ValueAndMatchingInfo_HardshipAndCategoryAndAnswerIsNull(job, value, hardship, category);
 
         // 2개 조건: job, value
-        List<Worry> twoMatching1 = worryRepository.findByMatchingInfo_JobAndMatchingInfo_ValueAndCategory(job, value, category);
+        List<Worry> twoMatching1 = worryRepository.findByMatchingInfo_JobAndMatchingInfo_ValueAndCategoryAndAnswerIsNull(job, value, category);
         // 2개 조건: job, hardship
-        List<Worry> twoMatching2 = worryRepository.findByMatchingInfo_JobAndMatchingInfo_HardshipAndCategory(job, hardship, category);
+        List<Worry> twoMatching2 = worryRepository.findByMatchingInfo_JobAndMatchingInfo_HardshipAndCategoryAndAnswerIsNull(job, hardship, category);
         // 2개 조건: value, hardship
-        List<Worry> twoMatching3 = worryRepository.findByMatchingInfo_ValueAndMatchingInfo_HardshipAndCategory(value, hardship, category);
+        List<Worry> twoMatching3 = worryRepository.findByMatchingInfo_ValueAndMatchingInfo_HardshipAndCategoryAndAnswerIsNull(value, hardship, category);
         // 2개 조건 결합(Set으로 중복 제거)
         Set<Worry> twoMatching = new HashSet<>();
         twoMatching.addAll(twoMatching1);
@@ -239,11 +239,11 @@ public class WorryService {
         twoMatching.addAll(twoMatching3);
 
         // 1개 조건: job
-        List<Worry> oneMatching1 = worryRepository.findByMatchingInfo_JobAndCategory(job, category);
+        List<Worry> oneMatching1 = worryRepository.findByMatchingInfo_JobAndCategoryAndAnswerIsNull(job, category);
         // 1개 조건: value
-        List<Worry> oneMatching2 = worryRepository.findByMatchingInfo_ValueAndCategory(value, category);
+        List<Worry> oneMatching2 = worryRepository.findByMatchingInfo_ValueAndCategoryAndAnswerIsNull(value, category);
         // 1개 조건: hardship
-        List<Worry> oneMatching3 = worryRepository.findByMatchingInfo_HardshipAndCategory(hardship, category);
+        List<Worry> oneMatching3 = worryRepository.findByMatchingInfo_HardshipAndCategoryAndAnswerIsNull(hardship, category);
         // 1개 조건 결합(Set으로 중복 제거)
         Set<Worry> oneMatching = new HashSet<>();
         oneMatching.addAll(oneMatching1);
@@ -251,7 +251,7 @@ public class WorryService {
         oneMatching.addAll(oneMatching3);
 
         // 0개 조건
-        List<Worry> zeroMatching = worryRepository.findByCategory(category);
+        List<Worry> zeroMatching = worryRepository.findByCategoryAndAnswerIsNull(category);
 
         // 랜덤으로 3개 뽑기
         Random random = new Random();

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -231,8 +231,6 @@ public class WorryService {
         // 유저 타입 검사
         userService.checkIfJunior(user);
 
-        String userDescription = makeAuthorName(user);
-
         Worry worry = findById(worryId);
 
         // 본인 고민이 아닌 경우, 에러 반환
@@ -246,6 +244,7 @@ public class WorryService {
         }
 
         Answer answer = worry.getAnswer();
+        String userDescription = makeAuthorName(answer.getSenior());
 
         return GetAnswerResponse.juniorVer.builder()
                 .content(answer.getContent())

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -253,6 +253,40 @@ public class WorryService {
                 .build();
     }
 
+    /**
+     * 답변 상세 조회(SENIOR ver)
+     */
+    public GetAnswerResponse.seniorVer getAnswerForSenior(Long userId, Long worryId) {
+
+        log.info("[답변 상세 조회(SENIOR ver)] userId={}, worryId={}", userId, worryId);
+
+        User user = userService.findById(userId);
+
+        // 유저 타입 검사
+        userService.checkIfSenior(user);
+
+        Worry worry = findById(worryId);
+
+        // 미답변 고민일 경우, 에러 반환
+        if(worry.getAnswer() == null) {
+            throw new GeneralException(ErrorStatus.WORRY_UNANSWERED);
+        }
+
+        Answer answer = worry.getAnswer();
+
+        // 본인 답변이 아닌 경우, 에러 반환
+        if(answer.getSenior() != user) {
+            throw new GeneralException(ErrorStatus.ANSWER_NOT_MINE);
+        }
+
+        return GetAnswerResponse.seniorVer.builder()
+                .content(answer.getContent())
+                .audioUrl(answer.getAudioUrl())
+                .imageUrl(answer.getImageUrl())
+                .build();
+    }
+
+
     // 매칭 고민 목록 조회
     private List<Worry> getMatchingWorries(JobCategory job, ValueCategory value, HardshipCategory hardship, WorryCategory category) {
         // 3개 조건 모두 일치하는 Worry들

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -2,17 +2,11 @@ package com.weve.service;
 
 import com.weve.common.api.exception.GeneralException;
 import com.weve.common.api.payload.code.status.ErrorStatus;
-import com.weve.domain.Answer;
-import com.weve.domain.MatchingInfo;
-import com.weve.domain.User;
-import com.weve.domain.Worry;
+import com.weve.domain.*;
 import com.weve.domain.enums.*;
 import com.weve.dto.gemini.ExtractedCategoriesFromText;
 import com.weve.dto.request.CreateWorryRequest;
-import com.weve.dto.response.CreateWorryResponse;
-import com.weve.dto.response.GetAnswerResponse;
-import com.weve.dto.response.GetWorriesResponse;
-import com.weve.dto.response.GetWorryResponse;
+import com.weve.dto.response.*;
 import com.weve.repository.WorryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -283,6 +277,39 @@ public class WorryService {
                 .content(answer.getContent())
                 .audioUrl(answer.getAudioUrl())
                 .imageUrl(answer.getImageUrl())
+                .build();
+    }
+
+    /**
+     * 감사편지 상세 조회(JUNIOR ver)
+     */
+    public GetAppreciateResponse.juniorVer getAppreciateForJunior(Long userId, Long worryId) {
+
+        log.info("[감사편지 상세 조회(JUNIOR ver)] userId={}, worryId={}", userId, worryId);
+
+        User user = userService.findById(userId);
+
+        // 유저 타입 검사
+        userService.checkIfJunior(user);
+
+        Worry worry = findById(worryId);
+
+        // 본인 고민이 아닌 경우, 에러 반환
+        if(worry.getJunior() != user) {
+            throw new GeneralException(ErrorStatus.WORRY_NOT_MINE);
+        }
+
+        // 감사인사가 존재하지 않는 고민일 경우, 에러 반환
+        if(worry.getAppreciate() == null) {
+            throw new GeneralException(ErrorStatus.WORRY_APPRECIATE_NOT_FOUND);
+        }
+
+        Appreciate appreciate = worry.getAppreciate();
+        String userDescription = makeAuthorName(user);
+
+        return GetAppreciateResponse.juniorVer.builder()
+                .content(appreciate.getContent())
+                .author(userDescription)
                 .build();
     }
 

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -2,6 +2,7 @@ package com.weve.service;
 
 import com.weve.common.api.exception.GeneralException;
 import com.weve.common.api.payload.code.status.ErrorStatus;
+import com.weve.domain.Answer;
 import com.weve.domain.MatchingInfo;
 import com.weve.domain.User;
 import com.weve.domain.Worry;
@@ -9,6 +10,7 @@ import com.weve.domain.enums.*;
 import com.weve.dto.gemini.ExtractedCategoriesFromText;
 import com.weve.dto.request.CreateWorryRequest;
 import com.weve.dto.response.CreateWorryResponse;
+import com.weve.dto.response.GetAnswerResponse;
 import com.weve.dto.response.GetWorriesResponse;
 import com.weve.dto.response.GetWorryResponse;
 import com.weve.repository.WorryRepository;
@@ -185,11 +187,7 @@ public class WorryService {
         // 유저 타입 검사
         userService.checkIfJunior(user);
 
-        String userDescription = String.format("%s에 사는 %d세 %s",
-                user.getNationality(),
-                Period.between(user.getBirth(), LocalDate.now()).getYears(),
-                user.getName()
-        );
+        String userDescription = makeAuthorName(user);
 
         Worry worry = findById(worryId);
 
@@ -218,6 +216,41 @@ public class WorryService {
                 .nationality(worry.getJunior().getNationality())
                 .content(worry.getContent())
                 .audioUrl(worry.getAudioUrl())
+                .build();
+    }
+
+    /**
+     * 답변 상세 조회(JUNIOR ver)
+     */
+    public GetAnswerResponse.juniorVer getAnswerForJunior(Long userId, Long worryId) {
+
+        log.info("[답변 상세 조회(JUNIOR ver)] userId={}, worryId={}", userId, worryId);
+
+        User user = userService.findById(userId);
+
+        // 유저 타입 검사
+        userService.checkIfJunior(user);
+
+        String userDescription = makeAuthorName(user);
+
+        Worry worry = findById(worryId);
+
+        // 본인 고민이 아닌 경우, 에러 반환
+        if(worry.getJunior() != user) {
+            throw new GeneralException(ErrorStatus.WORRY_NOT_MINE);
+        }
+
+        // 미답변 고민일 경우, 에러 반환
+        if(worry.getAnswer() == null) {
+            throw new GeneralException(ErrorStatus.WORRY_UNANSWERED);
+        }
+
+        Answer answer = worry.getAnswer();
+
+        return GetAnswerResponse.juniorVer.builder()
+                .content(answer.getContent())
+                .author(userDescription)
+                .imageUrl(answer.getImageUrl())
                 .build();
     }
 
@@ -316,6 +349,15 @@ public class WorryService {
                 category, selectedFromThree, selectedFromTwo, selectedFromOne, selectedFromZero);
 
         return responseList;
+    }
+
+    // 작성자 소개란 생성
+    private String makeAuthorName(User user) {
+        return String.format("%s에 사는 %d세 %s",
+                user.getNationality(),
+                Period.between(user.getBirth(), LocalDate.now()).getYears(),
+                user.getName()
+        );
     }
 
     // id로 Worry 검색

--- a/src/main/java/com/weve/service/WorryService.java
+++ b/src/main/java/com/weve/service/WorryService.java
@@ -191,8 +191,7 @@ public class WorryService {
                 user.getName()
         );
 
-        Worry worry = worryRepository.findById(worryId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.WORRY_NOT_FOUND));
+        Worry worry = findById(worryId);
 
         return GetWorryResponse.juniorVer.builder()
                 .content(worry.getContent())
@@ -212,8 +211,7 @@ public class WorryService {
         // 유저 타입 검사
         userService.checkIfSenior(user);
 
-        Worry worry = worryRepository.findById(worryId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.WORRY_NOT_FOUND));
+        Worry worry = findById(worryId);
 
         return GetWorryResponse.seniorVer.builder()
                 .author(worry.getJunior().getName())
@@ -318,5 +316,11 @@ public class WorryService {
                 category, selectedFromThree, selectedFromTwo, selectedFromOne, selectedFromZero);
 
         return responseList;
+    }
+
+    // id로 Worry 검색
+    public Worry findById(Long worryId) {
+        return worryRepository.findById(worryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.WORRY_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #21 

## 💻 작업 내용
- [x] 감사인사 상세 조회(청년) API 구현

## ✅ PR Point
- 고민 상세 조회(청년)에서 분리된 API로, 청년 UI에서 답변과 감사인사를 worryId로 조회할 수 있도록 WORRY 리소스(```/worries```)를 중심으로 구현했습니다. 
- 해당 PR은 #22 의 후속 작업입니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
<img width="1003" alt="스크린샷 2025-02-24 오후 6 07 30" src="https://github.com/user-attachments/assets/a841a96e-100c-4a7f-8aeb-70b2f09a8618" />

