### PR TITLE
[GCP] 배포 & CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -42,7 +42,7 @@ jobs:
     # Docker build
     - name: Docker build
       run: |
-        docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}"
+        echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
         docker build -t weve_spring .
         docker tag weve_spring weve0/weve:${GITHUB_SHA::7}
         docker push weve0/weve:${GITHUB_SHA::7}

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # 기본 체크아웃
+    - name: Checkout
+      uses: actions/checkout@v3
+    # Gradlew 실행 허용
+    - name: Run chmod to make gradlew executable
+      run: chmod +x ./gradlew
+    # JDK 11 세팅
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+    # 환경 변수 설정
+    - name: Set environment values
+      run: |
+        cd ./src/main/resources
+        touch ./application.yml
+        echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./application.yml
+      shell: bash
+    # Gradle build (Test 제외)
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: clean build -x test

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -31,8 +31,10 @@ jobs:
     - name: Set environment values
       run: |
         cd ./src/main/resources
+        mkdir -p ./gcp
         touch ./application.yml
         echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./application.yml
+        echo "${{ secrets.GCP_SERVICE_KEY }}" | base64 --decode > ./gcp/service-key.json
       shell: bash
     # Gradle build (Test 제외)
     - name: Build with Gradle

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -57,19 +57,19 @@ jobs:
         script: |
           sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
           
-        # 기존 컨테이너 중지 및 삭제
+          # 기존 컨테이너 중지 및 삭제
           sudo docker stop weve_spring || true
           sudo docker rm weve_spring || true
           
-        # 기존 이미지 삭제 (오래된 이미지 정리)
+          # 기존 이미지 삭제 (오래된 이미지 정리)
           sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7} || true
           
-        # 새로운 이미지 가져오기
+          # 새로운 이미지 가져오기
           sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7}
           
-        # 최신 이미지 태깅
+          # 최신 이미지 태깅
           sudo docker tag ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7} weve_spring
           
-        # 기존 컨테이너를 완전히 삭제한 후 다시 실행
+          # 기존 컨테이너를 완전히 삭제한 후 다시 실행
           sudo docker-compose down
           sudo docker-compose up -d --force-recreate

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -44,5 +44,18 @@ jobs:
       run: |
         echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
         docker build -t weve_spring .
-        docker tag weve_spring weve0/weve:${GITHUB_SHA::7}
-        docker push weve0/weve:${GITHUB_SHA::7}
+        docker tag weve_spring ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7}
+        docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7}
+    # Deploy
+    - name: Deploy
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.SSH_HOST }}
+        username: ${{ secrets.SSH_USERNAME }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        envs: GITHUB_SHA
+        script: |
+          sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7}
+          sudo docker tag ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7} weve_spring
+          sudo docker-compose up -d

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -42,7 +42,7 @@ jobs:
     # Docker build
     - name: Docker build
       run: |
-        docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+        docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}"
         docker build -t weve_spring .
         docker tag weve_spring weve0/weve:${GITHUB_SHA::7}
         docker push weve0/weve:${GITHUB_SHA::7}

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -39,3 +39,10 @@ jobs:
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:
         arguments: clean build -x test
+    # Docker build
+    - name: Docker build
+      run: |
+        docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+        docker build -t weve_spring .
+        docker tag weve_spring weve0/weve:${GITHUB_SHA::7}
+        docker push weve0/weve:${GITHUB_SHA::7}

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -56,6 +56,20 @@ jobs:
         envs: GITHUB_SHA
         script: |
           sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+          
+        # 기존 컨테이너 중지 및 삭제
+          sudo docker stop weve_spring || true
+          sudo docker rm weve_spring || true
+          
+        # 기존 이미지 삭제 (오래된 이미지 정리)
+          sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7} || true
+          
+        # 새로운 이미지 가져오기
           sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7}
+          
+        # 최신 이미지 태깅
           sudo docker tag ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${GITHUB_SHA::7} weve_spring
-          sudo docker-compose up -d
+          
+        # 기존 컨테이너를 완전히 삭제한 후 다시 실행
+          sudo docker-compose down
+          sudo docker-compose up -d --force-recreate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,11 @@
-name: Deploy
+name: deploy
 
 on:
   push:
     branches: [ "develop" ]
   pull_request:
     branches: [ "develop" ]
+    types: [closed]
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/weve-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/src/main/java/com/weve/controller/HealthCheckController.java
+++ b/src/main/java/com/weve/controller/HealthCheckController.java
@@ -1,0 +1,15 @@
+package com.weve.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// @Hidden (스웨거 숨김)
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/health")
+    public ResponseEntity<String> HealthCheck() {
+        return ResponseEntity.ok("Health Check");
+    }
+}

--- a/src/main/java/com/weve/controller/HealthCheckController.java
+++ b/src/main/java/com/weve/controller/HealthCheckController.java
@@ -10,6 +10,6 @@ public class HealthCheckController {
 
     @GetMapping("/health")
     public ResponseEntity<String> HealthCheck() {
-        return ResponseEntity.ok("Health Check");
+        return ResponseEntity.ok("Health Check!");
     }
 }

--- a/src/main/java/com/weve/controller/HealthCheckController.java
+++ b/src/main/java/com/weve/controller/HealthCheckController.java
@@ -10,6 +10,6 @@ public class HealthCheckController {
 
     @GetMapping("/health")
     public ResponseEntity<String> HealthCheck() {
-        return ResponseEntity.ok("Health Check!");
+        return ResponseEntity.ok("Health Check");
     }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #31

## 💻 작업 내용
- [x]  Cloud SQL 인스턴스 생성 및 연동
- [x]  GCP 배포 (GCP VM, Docker)
- [x]  도메인(```gdg-weve.store```) 적용 및 https 배포 (Nginx, Certbot)
- [x]  CI/CD 구축 (Github Actions)

## ✅ PR Point
- AWS 배포 방식과 거의 동일하여, 특별한 차이점은 없었습니다. 하단에 기재한 자료들 보면서 배포 진행했으니, 나중에 참고하시면 좋을 것 같습니다.
  <details>
    <summary>로컬에서 Cloud SQL 연동하기 (비밀번호는 노션 계정 페이지에 정리해 두었습니다.)</summary>
    <img width="706" alt="스크린샷 2025-03-11 오전 9 55 24" src="https://github.com/user-attachments/assets/56e1a420-8de0-43e6-bddb-0278670581b0" />
  </details>
- 현재 GCP 환경에서 실행 중인 Docker 컨테이너 이름: weve_spring
- 현재는 백엔드 개발 진행 중이라 develop 브랜치를 기준으로 배포 스크립트를 설정했습니다. (develop에 push하거나 PR이 merge될 경우 배포 프로세스 실행) API 1차 개발 완료 후, 운영 및 리팩토링 단계에서 main 브랜치로 변경할 예정입니다.

## 📚 Reference
- [[Docker+GCP로 Springboot 배포 총정리(AWS EC2,RDS 대신 GCP VM,cloud SQL을 써보아요)](https://choo.oopy.io/5c999170-dde5-4418-addc-00a0d263287c)](https://choo.oopy.io/5c999170-dde5-4418-addc-00a0d263287c)

- [[GCP SQL(MySQL) 최저 비용으로 인스턴스 생성하기](https://velog.io/@jx7789/GCP-SQLMySQL-%EC%B5%9C%EC%A0%80-%EB%B9%84%EC%9A%A9%EC%9C%BC%EB%A1%9C-%EC%9D%B8%EC%8A%A4%ED%84%B4%EC%8A%A4-%EC%83%9D%EC%84%B1%ED%95%98%EA%B8%B0)](https://velog.io/@jx7789/GCP-SQLMySQL-%EC%B5%9C%EC%A0%80-%EB%B9%84%EC%9A%A9%EC%9C%BC%EB%A1%9C-%EC%9D%B8%EC%8A%A4%ED%84%B4%EC%8A%A4-%EC%83%9D%EC%84%B1%ED%95%98%EA%B8%B0)

- [[[GCP] Spring 서버를 https와 도메인 적용해 GCP에 배포하기 - 2](https://myeunee.tistory.com/32)](https://myeunee.tistory.com/32)

- [[GithubActions로 CICD구축-GCP편 (with Springboot) (BeachCombine프로젝트)](https://choo.oopy.io/79bee99c-5768-4817-b926-c23e4120bcf4)](https://choo.oopy.io/79bee99c-5768-4817-b926-c23e4120bcf4)