### PR TITLE
[API] Swagger 내 Content-Type 표시 문제 해결

### DIFF
--- a/src/main/java/com/weve/controller/GcsController.java
+++ b/src/main/java/com/weve/controller/GcsController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +27,7 @@ public class GcsController {
 
     private final GcsService gcsService;
 
-    @PostMapping("/upload")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "파일 업로드", description = "파일을 업로드하여 URL을 생성합니다.")
     public BasicResponse<UploadFileResponse> uploadFile(@RequestPart(value = "file") MultipartFile multipartFile) throws IOException {
 


### PR DESCRIPTION
## 💻 작업 내용
- [x] @PostMapping 애노테이션의 consume 파라미터를 활용하여 들어오는 Content-Type을 지정

## ✅ PR Point
- Swagger에서 파일 업로드 API Request의 Content-Type 형식이 application/json로 표시되어 multipart/form-data로 잡히도록 수정했습니다.
- 수정사항이 적으며, 프론트 측의 원활한 Swagger 사용을 위해 바로 머지하겠습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
Before
<img width="1412" alt="스크린샷 2025-03-14 오후 10 19 13" src="https://github.com/user-attachments/assets/fc766486-72b9-4080-836f-773b6eb639ec" />
After
<img width="1411" alt="스크린샷 2025-03-14 오후 10 19 51" src="https://github.com/user-attachments/assets/b165447a-d0e0-48dd-a191-fbefbbad700c" />

## 📚 Reference
- https://velog.io/@jsb100800/Spring-boot-Swagger-issue1