### PR TITLE
[USER] 문자인증용 도메인 속성 분리 리팩터링

### DIFF
--- a/src/main/java/com/weve/domain/Sms.java
+++ b/src/main/java/com/weve/domain/Sms.java
@@ -26,4 +26,16 @@ public class Sms extends BaseEntity {
 
     @Column
     private LocalDateTime smsCodeExpiry;
+
+    // smsCode 갱신
+    public void updatesmsCode(String code, LocalDateTime expiry) {
+        this.smsCode = code;
+        this.smsCodeExpiry = expiry;
+    }
+
+    // smsCode 초기화
+    public void clearSmsCode() {
+        this.smsCode = null;
+        this.smsCodeExpiry = null;
+    }
 }

--- a/src/main/java/com/weve/domain/Sms.java
+++ b/src/main/java/com/weve/domain/Sms.java
@@ -21,9 +21,6 @@ public class Sms extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "phone_number", nullable = false)
-    private String phoneNumber;
-
     @Column
     private String smsCode;
 

--- a/src/main/java/com/weve/domain/Sms.java
+++ b/src/main/java/com/weve/domain/Sms.java
@@ -1,0 +1,32 @@
+package com.weve.domain;
+
+import com.weve.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "sms")
+public class Sms extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+
+    @Column
+    private String smsCode;
+
+    @Column
+    private LocalDateTime smsCodeExpiry;
+}

--- a/src/main/java/com/weve/domain/User.java
+++ b/src/main/java/com/weve/domain/User.java
@@ -49,10 +49,4 @@ public class User extends BaseEntity {
 
     @Embedded
     private MatchingInfo matchingInfo;
-
-    @Column
-    private String smsCode;
-
-    @Column
-    private LocalDateTime smsCodeExpiry;
 }

--- a/src/main/java/com/weve/repository/SmsRepository.java
+++ b/src/main/java/com/weve/repository/SmsRepository.java
@@ -1,0 +1,11 @@
+package com.weve.repository;
+
+import com.weve.domain.Sms;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SmsRepository extends JpaRepository<Sms, Long> {
+    Optional<Sms> findByUserPhoneNumber(String phoneNumber);
+
+}

--- a/src/main/java/com/weve/service/MessageService.java
+++ b/src/main/java/com/weve/service/MessageService.java
@@ -1,6 +1,8 @@
 package com.weve.service;
 
+import com.weve.domain.Sms;
 import com.weve.domain.User;
+import com.weve.repository.SmsRepository;
 import com.weve.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +29,7 @@ public class MessageService {
 
     private final DefaultMessageService messageService; // DefaultMessageService 주입
     private final UserRepository userRepository;
+    private final SmsRepository smsRepository;
 
     @Value("${coolsms.apikey}")
     private String apiKey;
@@ -53,7 +56,6 @@ public class MessageService {
         String randomNum = createRandomNumber();
         log.info("생성된 인증번호: " + randomNum);
 
-        // SMS 객체 생성
         Message message = new Message();
         message.setFrom(fromNumber);
         message.setTo(phoneNumber);
@@ -64,21 +66,26 @@ public class MessageService {
             SingleMessageSentResponse response = messageService.sendOne(new SingleMessageSendingRequest(message));
             log.info("SMS 전송 성공: " + response);
 
-            // MySQL에 인증번호 저장 (기존 번호 갱신)
-            Optional<User> user = userRepository.findByPhoneNumber(phoneNumber);
-            if (user.isPresent()) {
-                User updatedUser = user.get().toBuilder()
-                        .smsCode(randomNum)
-                        .smsCodeExpiry(LocalDateTime.now().plusMinutes(5))  // 5분제한
-                        .build();
-                userRepository.save(updatedUser);
+            // 사용자 조회
+            Optional<User> userOpt = userRepository.findByPhoneNumber(phoneNumber);
+            if (userOpt.isEmpty()) {
+                log.warn("해당 전화번호를 가진 유저가 존재하지 않습니다.");
+                return "해당 유저가 존재하지 않습니다.";
+            }
+            User user = userOpt.get();
+
+            // Sms 정보 업데이트
+            Optional<Sms> smsOpt = smsRepository.findByUserPhoneNumber(phoneNumber);
+            if (smsOpt.isPresent()) {
+                Sms sms = smsOpt.get();
+                sms.updatesmsCode(randomNum, LocalDateTime.now().plusMinutes(5));
             } else {
-                User newUser = User.builder()
-                        .phoneNumber(phoneNumber)
+                Sms sms = Sms.builder()
+                        .user(user)
                         .smsCode(randomNum)
                         .smsCodeExpiry(LocalDateTime.now().plusMinutes(5))
                         .build();
-                userRepository.save(newUser);
+                smsRepository.save(sms);
             }
 
             return "문자 전송이 완료되었습니다.";
@@ -90,16 +97,13 @@ public class MessageService {
 
     // 인증번호 검증
     public boolean verifySMSCode(String phoneNumber, String inputCode) {
-        Optional<User> user = userRepository.findByPhoneNumber(phoneNumber);
-        if (user.isPresent()) {
-            User foundUser = user.get();
-            if (foundUser.getSmsCode().equals(inputCode) &&
-                    foundUser.getSmsCodeExpiry().isAfter(LocalDateTime.now())) {
-                User updatedUser = foundUser.toBuilder()
-                        .smsCode(null)
-                        .smsCodeExpiry(null)
-                        .build();
-                userRepository.save(updatedUser);
+        Optional<Sms> smsOpt = smsRepository.findByUserPhoneNumber(phoneNumber);
+        if (smsOpt.isPresent()) {
+            Sms sms = smsOpt.get();
+            if (sms.getSmsCode().equals(inputCode) &&
+                    sms.getSmsCodeExpiry().isAfter(LocalDateTime.now())) {
+                sms.clearSmsCode(); // code, expiry 초기화
+                smsRepository.save(sms);
                 return true;
             }
         }

--- a/src/main/java/com/weve/service/MessageService.java
+++ b/src/main/java/com/weve/service/MessageService.java
@@ -51,7 +51,7 @@ public class MessageService {
     @Transactional
     public String sendSMS(String phoneNumber) {
         String randomNum = createRandomNumber();
-        System.out.println("생성된 인증번호: " + randomNum);
+        log.info("생성된 인증번호: " + randomNum);
 
         // SMS 객체 생성
         Message message = new Message();
@@ -62,7 +62,7 @@ public class MessageService {
 
         try {
             SingleMessageSentResponse response = messageService.sendOne(new SingleMessageSendingRequest(message));
-            System.out.println("SMS 전송 성공: " + response);
+            log.info("SMS 전송 성공: " + response);
 
             // MySQL에 인증번호 저장 (기존 번호 갱신)
             Optional<User> user = userRepository.findByPhoneNumber(phoneNumber);
@@ -83,7 +83,7 @@ public class MessageService {
 
             return "문자 전송이 완료되었습니다.";
         } catch (Exception e) {
-            System.err.println("SMS 전송 실패: " + e.getMessage());
+            log.info("SMS 전송 실패: " + e.getMessage());
             return "문자 전송 실패";
         }
     }


### PR DESCRIPTION
## 🔥 Related Issues
- close #46
## 💻 작업 내용
- [x] ~ sms 도메인 생성 (기존 user 속성 제거)
- [x] ~ 로직 적용 및 변경

## ✅ PR Point
- Redis를 통한 sql 분리는 레디스 공부 후 진행할 예정입니다.
- sms 테이블에서 user_id를 외래키로 지정했습니다. phoneNumber는 변경가능성이 있어 이렇게 결정했습니다.
- sms repository에서 phoneNumber로 유저를 찾습니다. (sms -> user -> phoneNumber)

## ☀️ 스크린샷 / GIF / 화면 녹화
<img width="689" alt="스크린샷 2025-03-27 오후 8 54 55" src="https://github.com/user-attachments/assets/ba11ba58-d001-48be-8cb6-e996d282d38e" />
