### PR TITLE
[USER] 회원 탈퇴 기능 구현 및 프로필컬러 설정 추가 

### DIFF
--- a/src/main/java/com/weve/controller/AuthController.java
+++ b/src/main/java/com/weve/controller/AuthController.java
@@ -8,6 +8,8 @@ import com.weve.service.AuthService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.Basic;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -62,4 +64,15 @@ public class AuthController {
 
         return BasicResponse.onSuccess(token);
     }
+
+    // 회원 탈퇴
+    @DeleteMapping("/withdraw")
+    public BasicResponse<?> withdrawUser(@AuthenticationPrincipal UserDetails userDetails) {
+
+        String username = userDetails.getUsername();
+        authService.withdrawUser(username);
+
+        return BasicResponse.onSuccess(null);
+    }
+
 }

--- a/src/main/java/com/weve/domain/User.java
+++ b/src/main/java/com/weve/domain/User.java
@@ -49,4 +49,7 @@ public class User extends BaseEntity {
 
     @Embedded
     private MatchingInfo matchingInfo;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Sms sms;
 }

--- a/src/main/java/com/weve/domain/User.java
+++ b/src/main/java/com/weve/domain/User.java
@@ -3,6 +3,7 @@ package com.weve.domain;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.weve.domain.common.BaseEntity;
 import com.weve.domain.enums.Language;
+import com.weve.domain.enums.ProfileColor;
 import com.weve.domain.enums.UserType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -52,4 +53,7 @@ public class User extends BaseEntity {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Sms sms;
+
+    @Enumerated(EnumType.STRING)
+    private ProfileColor profileColor;
 }

--- a/src/main/java/com/weve/domain/enums/ProfileColor.java
+++ b/src/main/java/com/weve/domain/enums/ProfileColor.java
@@ -1,0 +1,9 @@
+package com.weve.domain.enums;
+
+public enum ProfileColor {
+    YELLO, // 주니어
+    GREEN, // 주니어
+    ORANGE, // 시니어
+    BLUE, // 시니어
+    PINK // 시니어
+}

--- a/src/main/java/com/weve/domain/enums/ProfileColor.java
+++ b/src/main/java/com/weve/domain/enums/ProfileColor.java
@@ -1,7 +1,7 @@
 package com.weve.domain.enums;
 
 public enum ProfileColor {
-    YELLO, // 주니어
+    YELLOW, // 주니어
     GREEN, // 주니어
     ORANGE, // 시니어
     BLUE, // 시니어

--- a/src/main/java/com/weve/dto/response/MypageResponse.java
+++ b/src/main/java/com/weve/dto/response/MypageResponse.java
@@ -3,6 +3,7 @@ package com.weve.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.weve.domain.User;
 import com.weve.domain.enums.Language;
+import com.weve.domain.enums.ProfileColor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +25,7 @@ public class MypageResponse {
     private Language language;
     private String phoneNumber;
     private String userType;
+    private ProfileColor profileColor;
 
     public static MypageResponse fromUser(User user) {
         return MypageResponse.builder()
@@ -34,6 +36,7 @@ public class MypageResponse {
                 .language(user.getLanguage())
                 .phoneNumber(user.getPhoneNumber())
                 .userType(user.getUserType().name()) // String 변환
+                .profileColor(user.getProfileColor())
                 .build();
     }
 

--- a/src/main/java/com/weve/repository/UserRepository.java
+++ b/src/main/java/com/weve/repository/UserRepository.java
@@ -7,4 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhoneNumber(String phoneNumber);
+
+    // 회원 탈퇴
+    void delete(User user);
 }

--- a/src/main/java/com/weve/service/AuthService.java
+++ b/src/main/java/com/weve/service/AuthService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.deser.DataFormatReaders;
 import com.weve.common.api.payload.BasicResponse;
 import com.weve.domain.User;
 import com.weve.domain.enums.Language;
+import com.weve.domain.enums.ProfileColor;
 import com.weve.domain.enums.UserType;
 import com.weve.repository.UserRepository;
 import com.weve.security.JwtUtil;
@@ -16,8 +17,11 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.weve.domain.enums.UserType.SENIOR;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +42,17 @@ public class AuthService {
         String countryCode = extractCountryCode(phoneNumber);
         String nationality = COUNTRY_NATIONALITY_MAP.getOrDefault(countryCode, "Unknown");
 
+        ProfileColor profileColor;
+        if (userType == SENIOR) {
+            // 시니어: ORANGE, BLUE, PINK 중 랜덤 선택
+            ProfileColor[] seniorColors = {ProfileColor.ORANGE, ProfileColor.BLUE, ProfileColor.PINK};
+            profileColor = seniorColors[new Random().nextInt(seniorColors.length)];
+        } else {
+            // 주니어: YELLOW, GREEN 중 랜덤 선택
+            ProfileColor[] juniorColors = {ProfileColor.YELLOW, ProfileColor.GREEN};
+            profileColor = juniorColors[new Random().nextInt(juniorColors.length)];
+        }
+
         User newUser = User.builder()
                 .name(name)
                 .phoneNumber(phoneNumber)
@@ -45,6 +60,7 @@ public class AuthService {
                 .userType(userType)
                 .language(language)
                 .nationality(nationality)
+                .profileColor(profileColor)
                 .build();
 
         userRepository.save(newUser);

--- a/src/main/java/com/weve/service/AuthService.java
+++ b/src/main/java/com/weve/service/AuthService.java
@@ -3,6 +3,7 @@ package com.weve.service;
 // 인증 서비스 (로그인하고 jwt 생성)
 
 import com.fasterxml.jackson.databind.deser.DataFormatReaders;
+import com.weve.common.api.payload.BasicResponse;
 import com.weve.domain.User;
 import com.weve.domain.enums.Language;
 import com.weve.domain.enums.UserType;
@@ -88,5 +89,13 @@ public class AuthService {
             return cleaned.substring(2); // → 01012345678
         }
         return cleaned; // 그 외의 경우는 그대로 반환
+    }
+
+    // 회원 탈퇴
+    public void withdrawUser(String username) {
+
+        User user = userRepository.findByPhoneNumber(username)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/com/weve/service/AuthService.java
+++ b/src/main/java/com/weve/service/AuthService.java
@@ -83,7 +83,7 @@ public class AuthService {
     );
 
     // 국가 코드 추출
-    public static final Pattern PHONE_PATTERN = Pattern.compile("^(\\+\\d{1,3})[\\s-]?(0\\d+)");
+    public static final Pattern PHONE_PATTERN = Pattern.compile("^(\\+\\d{1,3})");
 
     public String extractCountryCode(String phoneNumber) {
         Matcher matcher = PHONE_PATTERN.matcher(phoneNumber);

--- a/src/main/java/com/weve/service/UserService.java
+++ b/src/main/java/com/weve/service/UserService.java
@@ -74,7 +74,11 @@ public class UserService {
         String newPhoneNumber = request.getPhoneNumber() != null ? request.getPhoneNumber() : user.getPhoneNumber();
 
         String newCountryCode = authService.extractCountryCode(newPhoneNumber);
-        String newNationality = authService.COUNTRY_NATIONALITY_MAP.getOrDefault(newCountryCode, user.getNationality());
+//        String newNationality = authService.COUNTRY_NATIONALITY_MAP.getOrDefault(newCountryCode, user.getNationality());
+
+        String newNationality = AuthService.COUNTRY_NATIONALITY_MAP.containsKey(newCountryCode)
+                ? AuthService.COUNTRY_NATIONALITY_MAP.get(newCountryCode)
+                : user.getNationality();
 
         // 프로필 이미지 설정을 위한 유저 타입 검사
         ProfileColor profileColor;

--- a/src/main/java/com/weve/service/UserService.java
+++ b/src/main/java/com/weve/service/UserService.java
@@ -5,9 +5,7 @@ import com.weve.common.api.payload.BasicResponse;
 import com.weve.common.api.payload.code.status.ErrorStatus;
 import com.weve.domain.MatchingInfo;
 import com.weve.domain.User;
-import com.weve.domain.enums.HardshipCategory;
-import com.weve.domain.enums.JobCategory;
-import com.weve.domain.enums.ValueCategory;
+import com.weve.domain.enums.*;
 import com.weve.dto.gemini.ExtractedCategoriesFromText;
 import com.weve.dto.request.PatchMypageRequest;
 import com.weve.dto.request.SeniorInfoRequest;
@@ -18,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Random;
 
 import static com.weve.domain.enums.UserType.JUNIOR;
 import static com.weve.domain.enums.UserType.SENIOR;
@@ -76,12 +76,25 @@ public class UserService {
         String newCountryCode = authService.extractCountryCode(newPhoneNumber);
         String newNationality = authService.COUNTRY_NATIONALITY_MAP.getOrDefault(newCountryCode, user.getNationality());
 
+        // 프로필 이미지 설정을 위한 유저 타입 검사
+        ProfileColor profileColor;
+        if (user.getUserType() == UserType.SENIOR) {
+            // 시니어: ORANGE, BLUE, PINK 중 랜덤 선택
+            ProfileColor[] seniorColors = {ProfileColor.ORANGE, ProfileColor.BLUE, ProfileColor.PINK};
+            profileColor = seniorColors[new Random().nextInt(seniorColors.length)];
+        } else {
+            // 주니어: YELLOW, GREEN 중 랜덤 선택
+            ProfileColor[] juniorColors = {ProfileColor.YELLOW, ProfileColor.GREEN};
+            profileColor = juniorColors[new Random().nextInt(juniorColors.length)];
+        }
+
         User patchedUser = user.toBuilder()
                 .name(request.getName() != null ? request.getName() : user.getName())
                 .birth(request.getBirth() != null ? request.getBirth() : user.getBirth())
                 .phoneNumber(newPhoneNumber)
                 .language((request.getLanguage() != null ? request.getLanguage() : user.getLanguage()))
                 .nationality(newNationality)
+                .profileColor(profileColor)
                 .build();
 
         userRepository.save(patchedUser);


### PR DESCRIPTION
## 🔥 Related Issues
- close #49

## 💻 작업 내용
- [x] ~ 회원 탈퇴 기능 구현
- [x] ~ 프로필 컬러 랜덤 설정 구현
- [x] ~ 마이페이지 조회 / 마이페이지 정보 수정 호출 시 반환에 프로필 컬러 속성 추가 

## ✅ PR Point
시니어는 회원가입 시, 주니어는 마이페이지 정보 수정 시 프로필 컬러 지정됩니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
<img width="822" alt="스크린샷 2025-04-04 오후 7 46 06" src="https://github.com/user-attachments/assets/a3bd8e6f-5e26-435a-b723-5aa276ad1941" />
<img width="808" alt="스크린샷 2025-04-04 오후 7 46 24" src="https://github.com/user-attachments/assets/1ab2bfaa-591e-469f-8e38-dd44225b2d2f" />
